### PR TITLE
 codingstyle fix: optimize T_NGX_HTTP_SSL_HANDSHAKE_TIME macro

### DIFF
--- a/src/http/ngx_http_request.c
+++ b/src/http/ngx_http_request.c
@@ -683,18 +683,19 @@ ngx_http_create_request(ngx_connection_t *c)
 static void
 ngx_http_ssl_handshake(ngx_event_t *rev)
 {
-    u_char                   *p, buf[NGX_PROXY_PROTOCOL_MAX_HEADER + 1];
-    size_t                    size;
-    ssize_t                   n;
-    ngx_err_t                 err;
-    ngx_int_t                 rc;
+    u_char                    *p, buf[NGX_PROXY_PROTOCOL_MAX_HEADER + 1];
+    size_t                     size;
+    ssize_t                    n;
+    ngx_err_t                  err;
+    ngx_int_t                  rc;
+    ngx_connection_t          *c;
+    ngx_http_connection_t     *hc;
+    ngx_http_ssl_srv_conf_t   *sscf;
+    ngx_http_core_loc_conf_t  *clcf;
+
 #if (T_NGX_HTTP_SSL_HANDSHAKE_TIME)
     ngx_time_t               *tp;
 #endif
-    ngx_connection_t         *c;
-    ngx_http_connection_t    *hc;
-    ngx_http_ssl_srv_conf_t  *sscf;
-    ngx_http_core_loc_conf_t *clcf;
 
     c = rev->data;
     hc = c->data;


### PR DESCRIPTION

* diff after:

```
@@ -693,10 +634,6 @@ ngx_http_ssl_handshake(ngx_event_t *rev)
     ngx_http_ssl_srv_conf_t   *sscf;
     ngx_http_core_loc_conf_t  *clcf;

-#if (T_NGX_HTTP_SSL_HANDSHAKE_TIME)
-    ngx_time_t               *tp;
-#endif
-
```